### PR TITLE
Drop support for Node.js 4 and below

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/ember-cli/ember-disable-prototype-extensions.git"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "author": "Robert Jackson <me@rwjblue.com>",
   "license": "MIT",


### PR DESCRIPTION
... because Node 4 is no longer maintained by the Node.js team.

This PR will require a new major version release.